### PR TITLE
🔨Refactor: 게시글 전체 조회 기능 수정

### DIFF
--- a/src/main/kotlin/com/teamsparta/buysell/domain/member/controller/MemberController.kt
+++ b/src/main/kotlin/com/teamsparta/buysell/domain/member/controller/MemberController.kt
@@ -56,7 +56,7 @@ class MemberController(
     ): ResponseEntity<MemberResponse> {
         return ResponseEntity
             .status(HttpStatus.OK)
-            .body(memberService.updateMember(userPrincipal, request))
+            .body(memberService.updateMyProfile(userPrincipal, request))
     }
 
     @GetMapping
@@ -66,12 +66,12 @@ class MemberController(
     ): ResponseEntity<MemberResponse> {
         return ResponseEntity
             .status(HttpStatus.OK)
-            .body(memberService.getMember(userPrincipal))
+            .body(memberService.getMyProfile(userPrincipal))
     }
 
     @GetMapping("/{memberId}/posts")
     @Operation(summary = "작성한 게시글 조회", description = "작성한 모든 게시글을 조회합니다.")
-    fun getAllPosts(
+    fun getAllPostsMemberId(
         @PathVariable memberId:Int,
     ): ResponseEntity<List<PostResponse>> {
         val posts = memberService.getAllPostByMemberId(memberId)
@@ -95,7 +95,7 @@ class MemberController(
     fun pretendDelete(
         @AuthenticationPrincipal userPrincipal: UserPrincipal
     ):ResponseEntity<String>{
-        memberService.pretendDelete(userPrincipal)
+        memberService.signOut(userPrincipal)
         return ResponseEntity
             .status(HttpStatus.OK)
             .body("탈퇴 신청 완료!")

--- a/src/main/kotlin/com/teamsparta/buysell/domain/member/controller/MemberController.kt
+++ b/src/main/kotlin/com/teamsparta/buysell/domain/member/controller/MemberController.kt
@@ -5,12 +5,12 @@ import com.teamsparta.buysell.domain.member.dto.request.MemberProfileUpdateReque
 import com.teamsparta.buysell.domain.member.dto.request.SignUpRequest
 import com.teamsparta.buysell.domain.member.dto.response.MemberResponse
 import com.teamsparta.buysell.domain.member.service.MemberService
+import com.teamsparta.buysell.domain.member.service.SocialService
 import com.teamsparta.buysell.domain.post.dto.response.PostResponse
 import com.teamsparta.buysell.infra.security.UserPrincipal
+import com.teamsparta.buysell.infra.social.jwt.JwtDto
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
-import com.teamsparta.buysell.domain.member.service.SocialService
-import com.teamsparta.buysell.infra.social.jwt.JwtDto
 import jakarta.validation.Valid
 import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatus
@@ -59,14 +59,14 @@ class MemberController(
             .body(memberService.updateMember(userPrincipal, request))
     }
 
-    @GetMapping
+    @GetMapping("/{memberId}")
     @Operation(summary = "프로필 조회", description = "프로필을 조회합니다.")
     fun getProfile(
-        @AuthenticationPrincipal userPrincipal: UserPrincipal,
+        @PathVariable memberId:Int,
     ): ResponseEntity<MemberResponse> {
         return ResponseEntity
             .status(HttpStatus.OK)
-            .body(memberService.getMember(userPrincipal))
+            .body(memberService.getMember(memberId))
     }
 
     @GetMapping("/posts")

--- a/src/main/kotlin/com/teamsparta/buysell/domain/member/controller/MemberController.kt
+++ b/src/main/kotlin/com/teamsparta/buysell/domain/member/controller/MemberController.kt
@@ -59,22 +59,22 @@ class MemberController(
             .body(memberService.updateMember(userPrincipal, request))
     }
 
-    @GetMapping("/{memberId}")
+    @GetMapping
     @Operation(summary = "프로필 조회", description = "프로필을 조회합니다.")
     fun getProfile(
-        @PathVariable memberId:Int,
+        @AuthenticationPrincipal userPrincipal: UserPrincipal,
     ): ResponseEntity<MemberResponse> {
         return ResponseEntity
             .status(HttpStatus.OK)
-            .body(memberService.getMember(memberId))
+            .body(memberService.getMember(userPrincipal))
     }
 
-    @GetMapping("/posts")
-    @Operation(summary = "내가 쓴 게시글 조회", description = "내가 쓴 게시글을 조회합니다.")
+    @GetMapping("/{memberId}/posts")
+    @Operation(summary = "작성한 게시글 조회", description = "작성한 모든 게시글을 조회합니다.")
     fun getAllPosts(
-        @AuthenticationPrincipal userPrincipal: UserPrincipal,
+        @PathVariable memberId:Int,
     ): ResponseEntity<List<PostResponse>> {
-        val posts = memberService.getAllPostByUserPrincipal(userPrincipal)
+        val posts = memberService.getAllPostByMemberId(memberId)
         return ResponseEntity
             .status(HttpStatus.OK)
             .body(posts)

--- a/src/main/kotlin/com/teamsparta/buysell/domain/member/model/MemberStatus.kt
+++ b/src/main/kotlin/com/teamsparta/buysell/domain/member/model/MemberStatus.kt
@@ -1,5 +1,0 @@
-package com.teamsparta.buysell.domain.member.model
-
-enum class MemberStatus {
-    NORMAL, BANNED, PRETENDDELETE
-}

--- a/src/main/kotlin/com/teamsparta/buysell/domain/member/repository/MemberRepository.kt
+++ b/src/main/kotlin/com/teamsparta/buysell/domain/member/repository/MemberRepository.kt
@@ -1,10 +1,8 @@
 package com.teamsparta.buysell.domain.member.repository
 
 import com.teamsparta.buysell.domain.member.model.Member
-import com.teamsparta.buysell.domain.member.model.MemberStatus
 import org.springframework.data.jpa.repository.JpaRepository
 
 interface MemberRepository: JpaRepository<Member, Int> {
     fun findByEmail(email: String): Member?
-    fun findAllByStatus(status: MemberStatus) : List<Member>
 }

--- a/src/main/kotlin/com/teamsparta/buysell/domain/member/service/MemberService.kt
+++ b/src/main/kotlin/com/teamsparta/buysell/domain/member/service/MemberService.kt
@@ -10,10 +10,10 @@ import com.teamsparta.buysell.infra.security.UserPrincipal
 interface MemberService {
     fun signUp(request: SignUpRequest): MemberResponse
     fun login(request: LoginRequest): String
-    fun getMember(userPrincipal: UserPrincipal): MemberResponse?
-    fun updateMember(userPrincipal: UserPrincipal, request: MemberProfileUpdateRequest): MemberResponse
+    fun getMyProfile(userPrincipal: UserPrincipal): MemberResponse?
+    fun updateMyProfile(userPrincipal: UserPrincipal, request: MemberProfileUpdateRequest): MemberResponse
     fun getAllPostByMemberId(memberId:Int) : List<PostResponse>?
     fun getAllPostByLike(userPrincipal: UserPrincipal): List<PostResponse>?
-    fun pretendDelete(userPrincipal: UserPrincipal)
+    fun signOut(userPrincipal: UserPrincipal)
     //fun googleLogin(oAuth2User: OAuth2User): JwtDto
 }

--- a/src/main/kotlin/com/teamsparta/buysell/domain/member/service/MemberService.kt
+++ b/src/main/kotlin/com/teamsparta/buysell/domain/member/service/MemberService.kt
@@ -10,7 +10,7 @@ import com.teamsparta.buysell.infra.security.UserPrincipal
 interface MemberService {
     fun signUp(request: SignUpRequest): MemberResponse
     fun login(request: LoginRequest): String
-    fun getMember(userPrincipal: UserPrincipal): MemberResponse?
+    fun getMember(memberId:Int): MemberResponse?
     fun updateMember(userPrincipal: UserPrincipal, request: MemberProfileUpdateRequest): MemberResponse
     fun getAllPostByUserPrincipal(userPrincipal: UserPrincipal) : List<PostResponse>?
     fun getAllPostByLike(userPrincipal: UserPrincipal): List<PostResponse>?

--- a/src/main/kotlin/com/teamsparta/buysell/domain/member/service/MemberService.kt
+++ b/src/main/kotlin/com/teamsparta/buysell/domain/member/service/MemberService.kt
@@ -10,9 +10,9 @@ import com.teamsparta.buysell.infra.security.UserPrincipal
 interface MemberService {
     fun signUp(request: SignUpRequest): MemberResponse
     fun login(request: LoginRequest): String
-    fun getMember(memberId:Int): MemberResponse?
+    fun getMember(userPrincipal: UserPrincipal): MemberResponse?
     fun updateMember(userPrincipal: UserPrincipal, request: MemberProfileUpdateRequest): MemberResponse
-    fun getAllPostByUserPrincipal(userPrincipal: UserPrincipal) : List<PostResponse>?
+    fun getAllPostByMemberId(memberId:Int) : List<PostResponse>?
     fun getAllPostByLike(userPrincipal: UserPrincipal): List<PostResponse>?
     fun pretendDelete(userPrincipal: UserPrincipal)
     //fun googleLogin(oAuth2User: OAuth2User): JwtDto

--- a/src/main/kotlin/com/teamsparta/buysell/domain/member/service/MemberServiceImpl.kt
+++ b/src/main/kotlin/com/teamsparta/buysell/domain/member/service/MemberServiceImpl.kt
@@ -59,43 +59,47 @@ class MemberServiceImpl(
         return token
     }
 
-
+    // 현재 로그인 한 멤버 아이디 기준 정보 조회
     @Transactional
-    override fun getMember(userPrincipal: UserPrincipal): MemberResponse? {
+    override fun getMyProfile(userPrincipal: UserPrincipal): MemberResponse? {
         val member = memberRepository.findByIdOrNull(userPrincipal.id)
             ?: throw ModelNotFoundException("Member", userPrincipal.id)
         return member.toResponse()
-    } // 현재 로그인 한 멤버 아이디 기준 정보 조회
+    }
 
+    // 로그인 한 멤버 아이디 기준 정보 수정
     @Transactional
-    override fun updateMember(userPrincipal: UserPrincipal, request: MemberProfileUpdateRequest): MemberResponse {
+    override fun updateMyProfile(userPrincipal: UserPrincipal, request: MemberProfileUpdateRequest): MemberResponse {
         val member = memberRepository.findByIdOrNull(userPrincipal.id)
             ?: throw ModelNotFoundException("Member", userPrincipal.id)
         member.nickname = request.nickname
         member.birthday = request.birthday
        return memberRepository.save(member).toResponse()
-    } // 로그인 한 멤버 아이디 기준 정보 수정
+    }
 
+    // 멤버가 쓴 글 전체 조회
     override fun getAllPostByMemberId(memberId:Int): List<PostResponse>? {
         val member = memberRepository.findByIdOrNull(memberId)
             ?: throw ModelNotFoundException("member", memberId)
         val post = postRepository.findAllByMember(member)
         return post.map { it.toResponse() }
-    }// 멤버가 쓴 글 전체 조회
+    }
 
+    //내가 찜 한 글 전체 조회
     override fun getAllPostByLike(userPrincipal: UserPrincipal): List<PostResponse>? {
         val member = memberRepository.findByIdOrNull(userPrincipal.id)
             ?: throw ModelNotFoundException("member", userPrincipal.id)
         val like = likeRepository.findByMember(member)
         val post = like.map { it.post }
         return post.map { it.toResponse() }
-    }//내가 찜 한 글 전체 조회
+    }
 
-    override fun pretendDelete(userPrincipal: UserPrincipal) {
+    //회원 탈퇴 요청
+    override fun signOut(userPrincipal: UserPrincipal) {
         val member = memberInformation(userPrincipal)
 
         memberRepository.delete(member)
-    } //회원 탈퇴 요청
+    }
 
     private fun memberInformation(userPrincipal: UserPrincipal) = memberRepository.findByIdOrNull(userPrincipal.id)
         ?:throw ModelNotFoundException("member",userPrincipal.id)

--- a/src/main/kotlin/com/teamsparta/buysell/domain/member/service/MemberServiceImpl.kt
+++ b/src/main/kotlin/com/teamsparta/buysell/domain/member/service/MemberServiceImpl.kt
@@ -61,11 +61,11 @@ class MemberServiceImpl(
 
 
     @Transactional
-    override fun getMember(memberId:Int): MemberResponse? {
-        val foundMember = memberRepository.findByIdOrNull(memberId)
-            ?: throw ModelNotFoundException("Member",memberId)
-        return foundMember.toResponse()
-    } // 멤버 아이디 기준 정보 조회
+    override fun getMember(userPrincipal: UserPrincipal): MemberResponse? {
+        val member = memberRepository.findByIdOrNull(userPrincipal.id)
+            ?: throw ModelNotFoundException("Member", userPrincipal.id)
+        return member.toResponse()
+    } // 현재 로그인 한 멤버 아이디 기준 정보 조회
 
     @Transactional
     override fun updateMember(userPrincipal: UserPrincipal, request: MemberProfileUpdateRequest): MemberResponse {
@@ -74,14 +74,14 @@ class MemberServiceImpl(
         member.nickname = request.nickname
         member.birthday = request.birthday
        return memberRepository.save(member).toResponse()
-    } // 멤버 아이디 기준 정보 수정
+    } // 로그인 한 멤버 아이디 기준 정보 수정
 
-    override fun getAllPostByUserPrincipal(userPrincipal: UserPrincipal): List<PostResponse>? {
-        val member = memberRepository.findByIdOrNull(userPrincipal.id)
-            ?: throw ModelNotFoundException("member", userPrincipal.id)
+    override fun getAllPostByMemberId(memberId:Int): List<PostResponse>? {
+        val member = memberRepository.findByIdOrNull(memberId)
+            ?: throw ModelNotFoundException("member", memberId)
         val post = postRepository.findAllByMember(member)
         return post.map { it.toResponse() }
-    }//내가 쓴 글 전체 조회
+    }// 멤버가 쓴 글 전체 조회
 
     override fun getAllPostByLike(userPrincipal: UserPrincipal): List<PostResponse>? {
         val member = memberRepository.findByIdOrNull(userPrincipal.id)

--- a/src/main/kotlin/com/teamsparta/buysell/domain/member/service/MemberServiceImpl.kt
+++ b/src/main/kotlin/com/teamsparta/buysell/domain/member/service/MemberServiceImpl.kt
@@ -61,10 +61,10 @@ class MemberServiceImpl(
 
 
     @Transactional
-    override fun getMember(userPrincipal: UserPrincipal): MemberResponse? {
-        val member = memberRepository.findByIdOrNull(userPrincipal.id)
-            ?: throw ModelNotFoundException("Member", userPrincipal.id)
-        return member.toResponse()
+    override fun getMember(memberId:Int): MemberResponse? {
+        val foundMember = memberRepository.findByIdOrNull(memberId)
+            ?: throw ModelNotFoundException("Member",memberId)
+        return foundMember.toResponse()
     } // 멤버 아이디 기준 정보 조회
 
     @Transactional

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,7 +2,7 @@ spring:
   datasource:
     driver-class-name: org.postgresql.Driver
     url: ${postgresql.url}
-    username: test
+    username: ${postgresql.username}
     password: ${postgresql.password}
   jpa:
     hibernate:


### PR DESCRIPTION
## 의도
- 로그인 한 개인 한 명의 게시글을 모아보는 기능을 게시자를 기준으로 조회 할 수 있게 변경

## 주요 변경점
- 로그인 한 아이디 기준으로 전체 게시글을 조회 하는 기능이었는데,
 멤버아이디 입력 하여 전체 게시글 조회 하는 기능으로 변경 하였습니다.

## ETC
- 오타나 실수 발견하시면 적극적으로 말씀 해주세요.
- 의문 점 있으면 꼭 말씀 주세요.