### PR TITLE
✨Feat: 결제관련 예외처리 추가

### DIFF
--- a/src/main/kotlin/com/teamsparta/buysell/domain/member/model/Account.kt
+++ b/src/main/kotlin/com/teamsparta/buysell/domain/member/model/Account.kt
@@ -1,5 +1,6 @@
 package com.teamsparta.buysell.domain.member.model
 
+import com.teamsparta.buysell.infra.auditing.SoftDeleteEntity
 import jakarta.persistence.*
 
 @Entity

--- a/src/main/kotlin/com/teamsparta/buysell/domain/member/model/Account.kt
+++ b/src/main/kotlin/com/teamsparta/buysell/domain/member/model/Account.kt
@@ -8,8 +8,7 @@ class Account (
 
     @Column(name = "account_balance")
     var accountBalance: Long = 0
-
-){
+): SoftDeleteEntity() {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     var id: Int? = null
@@ -28,5 +27,8 @@ class Account (
 
     fun availableForPurchase(price: Long): Boolean{
         return accountBalance > price
+    }
+    fun refundToAccount(money: Long) {
+        accountBalance += money
     }
 }

--- a/src/main/kotlin/com/teamsparta/buysell/domain/order/controller/OrderController.kt
+++ b/src/main/kotlin/com/teamsparta/buysell/domain/order/controller/OrderController.kt
@@ -26,4 +26,15 @@ class OrderController(
             .body(orderService.createOrder(postId, createOrderRequest, principal))
     }
 
+    @DeleteMapping("/{orderId}")
+    fun cancelOrder(
+        @PathVariable postId: Int,
+        @PathVariable orderId: Int,
+        @AuthenticationPrincipal principal: UserPrincipal,
+    ): ResponseEntity<MessageResponse> {
+
+        return ResponseEntity
+            .status(HttpStatus.CREATED)
+            .body(orderService.cancelOrder(postId, orderId, principal))
+    }
 }

--- a/src/main/kotlin/com/teamsparta/buysell/domain/order/model/Order.kt
+++ b/src/main/kotlin/com/teamsparta/buysell/domain/order/model/Order.kt
@@ -18,7 +18,7 @@ class Order (
     val member: Member,
 
     @OneToOne(fetch = FetchType.LAZY )
-    var post: Post,
+    val post: Post,
 
     @Enumerated(EnumType.STRING)
     @Column(name = "order_state")

--- a/src/main/kotlin/com/teamsparta/buysell/domain/order/model/Order.kt
+++ b/src/main/kotlin/com/teamsparta/buysell/domain/order/model/Order.kt
@@ -18,7 +18,11 @@ class Order (
     val member: Member,
 
     @OneToOne(fetch = FetchType.LAZY )
-    var post: Post
+    var post: Post,
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "order_state")
+    var orderState: OrderState
 
 ){
     @Id

--- a/src/main/kotlin/com/teamsparta/buysell/domain/order/model/OrderState.kt
+++ b/src/main/kotlin/com/teamsparta/buysell/domain/order/model/OrderState.kt
@@ -1,0 +1,6 @@
+package com.teamsparta.buysell.domain.order.model
+
+enum class OrderState {
+    CANCELLED, // 결제 취소
+    COMPLED, // 결제 완료
+}

--- a/src/main/kotlin/com/teamsparta/buysell/domain/order/model/OrderState.kt
+++ b/src/main/kotlin/com/teamsparta/buysell/domain/order/model/OrderState.kt
@@ -2,5 +2,5 @@ package com.teamsparta.buysell.domain.order.model
 
 enum class OrderState {
     CANCELLED, // 결제 취소
-    COMPLED, // 결제 완료
+    COMPLETED, // 결제 완료
 }

--- a/src/main/kotlin/com/teamsparta/buysell/domain/order/service/OrderService.kt
+++ b/src/main/kotlin/com/teamsparta/buysell/domain/order/service/OrderService.kt
@@ -8,4 +8,5 @@ interface OrderService {
 
     fun createOrder(postId: Int, request: CreateOrderRequest, principal: UserPrincipal): MessageResponse
 
+    fun cancelOrder(postId: Int, orderId: Int, principal: UserPrincipal): MessageResponse
 }

--- a/src/main/kotlin/com/teamsparta/buysell/domain/order/service/OrderServiceImpl.kt
+++ b/src/main/kotlin/com/teamsparta/buysell/domain/order/service/OrderServiceImpl.kt
@@ -38,7 +38,7 @@ class OrderServiceImpl(
             phoneNumber = request.phoneNumber,
             member = member,
             post = post,
-            orderState = OrderState.COMPLED
+            orderState = OrderState.COMPLETED
         )
 
         member.account.payment(post.price)
@@ -58,7 +58,7 @@ class OrderServiceImpl(
         val order = orderRepository.findByIdOrNull(orderId)
             ?: throw ModelNotFoundException("Order", orderId)
 
-        if (order.orderState != OrderState.COMPLED) {
+        if (order.orderState != OrderState.COMPLETED) {
             throw IllegalStateException("이미 취소된 주문입니다.")
         }
 

--- a/src/main/kotlin/com/teamsparta/buysell/domain/order/service/OrderServiceImpl.kt
+++ b/src/main/kotlin/com/teamsparta/buysell/domain/order/service/OrderServiceImpl.kt
@@ -30,6 +30,9 @@ class OrderServiceImpl(
         val post = postRepository.findByIdOrNull(postId)
             ?: throw ModelNotFoundException("Post", postId)
 
+        post.myPostCheckPermission(principal)
+        post.outOfStockStatus()
+
         val order = Order(
             address = request.address,
             phoneNumber = request.phoneNumber,
@@ -39,6 +42,7 @@ class OrderServiceImpl(
         )
 
         member.account.payment(post.price)
+        post.isSoldOut = true
 
         orderRepository.save(order)
 

--- a/src/main/kotlin/com/teamsparta/buysell/domain/order/service/OrderServiceImpl.kt
+++ b/src/main/kotlin/com/teamsparta/buysell/domain/order/service/OrderServiceImpl.kt
@@ -5,6 +5,7 @@ import com.teamsparta.buysell.domain.exception.ModelNotFoundException
 import com.teamsparta.buysell.domain.member.repository.MemberRepository
 import com.teamsparta.buysell.domain.order.dto.request.CreateOrderRequest
 import com.teamsparta.buysell.domain.order.model.Order
+import com.teamsparta.buysell.domain.order.model.OrderState
 import com.teamsparta.buysell.domain.order.repository.OrderRepository
 import com.teamsparta.buysell.domain.post.repository.PostRepository
 import com.teamsparta.buysell.infra.security.UserPrincipal
@@ -33,13 +34,37 @@ class OrderServiceImpl(
             address = request.address,
             phoneNumber = request.phoneNumber,
             member = member,
-            post = post
+            post = post,
+            orderState = OrderState.COMPLED
         )
 
         member.account.payment(post.price)
 
         orderRepository.save(order)
 
-            return MessageResponse("결제가 완료되었습니다.")
-        }
+        return MessageResponse("결제가 완료되었습니다.")
     }
+
+    @Transactional
+    override fun cancelOrder(
+        postId: Int,
+        orderId: Int,
+        principal: UserPrincipal
+    ): MessageResponse {
+        val order = orderRepository.findByIdOrNull(orderId)
+            ?: throw ModelNotFoundException("Order", orderId)
+
+        if (order.orderState != OrderState.COMPLED) {
+            throw IllegalStateException("이미 취소된 주문입니다.")
+        }
+
+        val member = order.member
+        val refundAmount = order.post.price
+
+        member.account.refundToAccount(refundAmount)
+
+        order.orderState = OrderState.CANCELLED
+
+        return MessageResponse("주문이 취소되었습니다.")
+    }
+}

--- a/src/main/kotlin/com/teamsparta/buysell/domain/post/model/Post.kt
+++ b/src/main/kotlin/com/teamsparta/buysell/domain/post/model/Post.kt
@@ -54,28 +54,37 @@ class Post(
 
     fun checkPermission(
         principal: UserPrincipal
-    ){
-        if(member.id != principal.id)
+    ) {
+        if (member.id != principal.id)
             throw ForbiddenException("권한이 없습니다.")
     }
 
+
+    fun myPostCheckPermission(
+        principal: UserPrincipal
+    ) {
+        if (member.id == principal.id)
+            throw ForbiddenException("내 게시물에 리뷰를 작성할 수 없습니다.")
+    }
+
     //삭제된 게시글인지 확인하는 메서드
-    fun checkDelete(){
-        if(isDeleted) //삭제된 게시글로 판단될 경우
+    fun checkDelete() {
+        if (isDeleted) //삭제된 게시글로 판단될 경우
             throw ModelNotFoundException("Post", id)
     }
 }
 
-fun Post.toResponse(): PostResponse {
-    return PostResponse(
-        id = id!!,
-        title = title,
-        content = content,
-        createdName = member.nickname,
-        price = price,
-        isSoldout = isSoldOut,
-        comment = comment
-            .filter { !it.isDeleted }
-            .map { CommentResponse.toResponse(it) }
-    )
-}
+    fun Post.toResponse(): PostResponse {
+        return PostResponse(
+            id = id!!,
+            title = title,
+            content = content,
+            createdName = member.nickname,
+            price = price,
+            isSoldout = isSoldOut,
+            comment = comment
+                .filter { !it.isDeleted }
+                .map { CommentResponse.toResponse(it) }
+        )
+    }
+

--- a/src/main/kotlin/com/teamsparta/buysell/domain/post/model/Post.kt
+++ b/src/main/kotlin/com/teamsparta/buysell/domain/post/model/Post.kt
@@ -64,7 +64,13 @@ class Post(
         principal: UserPrincipal
     ) {
         if (member.id == principal.id)
-            throw ForbiddenException("내 게시물에 리뷰를 작성할 수 없습니다.")
+            throw ForbiddenException("본인의 게시물에 이용할 수 없는 서비스입니다.")
+    }
+
+    fun outOfStockStatus() {
+        if (isSoldOut) {
+            throw IllegalStateException("판매완료된 게시글입니다.")
+        }
     }
 
     //삭제된 게시글인지 확인하는 메서드

--- a/src/main/kotlin/com/teamsparta/buysell/domain/post/model/Post.kt
+++ b/src/main/kotlin/com/teamsparta/buysell/domain/post/model/Post.kt
@@ -61,9 +61,12 @@ class Post(
             throw ForbiddenException("권한이 없습니다.")
     }
 
-//    fun softDelete(){
-//        this.isDeleted = true
-//    }
+    fun myPostCheckPermission(
+        principal: UserPrincipal
+    ){
+        if(member.id != principal.id)
+            throw ForbiddenException("내 게시물에 리뷰를 작성할 수 없습니다.")
+    }
 }
 
 fun Post.toResponse(): PostResponse {

--- a/src/main/kotlin/com/teamsparta/buysell/domain/review/model/Review.kt
+++ b/src/main/kotlin/com/teamsparta/buysell/domain/review/model/Review.kt
@@ -8,9 +8,11 @@ import com.teamsparta.buysell.domain.review.dto.request.UpdateReviewRequest
 import com.teamsparta.buysell.infra.auditing.SoftDeleteEntity
 import com.teamsparta.buysell.infra.security.UserPrincipal
 import jakarta.persistence.*
+import org.hibernate.annotations.SQLDelete
 
 @Entity
 @Table(name = "review")
+@SQLDelete(sql = "UPDATE review SET is_deleted = true WHERE id = ?")
 class Review private constructor(
 
     @Column(name = "content")
@@ -39,7 +41,7 @@ class Review private constructor(
             throw ForbiddenException("수정 권한이 없습니다.")
     }
 
-    fun edit(
+    fun editReview(
         request: UpdateReviewRequest
     ) {
         this.content = request.content

--- a/src/main/kotlin/com/teamsparta/buysell/domain/review/service/ReviewServiceImpl.kt
+++ b/src/main/kotlin/com/teamsparta/buysell/domain/review/service/ReviewServiceImpl.kt
@@ -29,6 +29,8 @@ class ReviewServiceImpl(
         val member = memberRepository.findByIdOrNull(principal.id)
             ?: throw ModelNotFoundException("Member", principal.id)
 
+        post.myPostCheckPermission(principal)
+
         Review.makeEntity(
             request = request,
             post = post,

--- a/src/main/kotlin/com/teamsparta/buysell/domain/review/service/ReviewServiceImpl.kt
+++ b/src/main/kotlin/com/teamsparta/buysell/domain/review/service/ReviewServiceImpl.kt
@@ -53,7 +53,7 @@ class ReviewServiceImpl(
             ?: throw ModelNotFoundException("Review", reviewId)
 
         review.checkPermission(principal)
-        review.edit(request)
+        review.editReview(request)
 
         return MessageResponse("리뷰가 수정되었습니다.")
     }
@@ -70,7 +70,6 @@ class ReviewServiceImpl(
         review.checkPermission(principal)
 
         reviewRepository.delete(review)
-//        review.softDelete()
 
         return MessageResponse("리뷰가 삭제되었습니다.")
     }


### PR DESCRIPTION
## 의도
내가 쓴 게시물에 결제할 수 없습니다.
내가 쓴 게시물에 리뷰를 작성할 수 없습니다.
판매가 완료된 상품은 isSoldOut 값이 true로 변경됩니다.
주문상태를 관리할 수 있습니다.
결제 취소시 환불받을 수 있습니다.
판매 완료된 상품은 구매할 수 없습니다.

- 내용

## 주요 변경점
어떤 부분이 변경되었는지 적어주세요
- refundToAccount 메서드를 추가하여 환불 받을 수 있는 코드가 추가되었습니다.
- OrderState 클래스를 추가해 결제상태를 COMPLED, CANCELLED 로 관리할 수 있습니다.
- 주문 생성 시 주문상태가 COMPLED로 변경됩니다. 취소 시 CANCELLED로 변경됩니다.
- 내가 쓴 게시물에 결제할 시 IllegarStateException이 발생합니다.
- 내가 쓴 게시물에 리뷰를 작성할 시 IllegarStateException이 발생합니다. (이 부분은 결제한 사람만 리뷰를 작성하도록 수정할 계획입니다.)
- 판매 완료된 상품에 결제를 시도할 시 IllegarStateException이 발생합니다.

## ETC
리뷰어들에게 어떤 점을 검토해야하는지 알려주세요
- OrderServiceImpl의 createOrder부분이 수정되었으니 이 부분을 중점으로 검토 부탁드립니다.
