### PR TITLE
✨Feat: Post 수정시 이미지 수정기능 추가

### DIFF
--- a/src/main/kotlin/com/teamsparta/buysell/domain/post/dto/request/UpdatePostRequest.kt
+++ b/src/main/kotlin/com/teamsparta/buysell/domain/post/dto/request/UpdatePostRequest.kt
@@ -15,5 +15,6 @@ data class UpdatePostRequest(
     @Schema(description = "작성한 본문 내용", example = "본문 내용")
     val content: String,
     val price: Long,
-    val category: Category
+    val category: Category,
+    val imageUrl: String?
 )

--- a/src/main/kotlin/com/teamsparta/buysell/domain/post/model/Post.kt
+++ b/src/main/kotlin/com/teamsparta/buysell/domain/post/model/Post.kt
@@ -87,6 +87,7 @@ class Post(
         this.content = request.content
         this.price = request.price
         this.category = request.category
+        this.imageUrl = request.imageUrl
     }
 
     fun toListResponse(): PostListResponse {

--- a/src/test/kotlin/com/teamsparta/buysell/domain/post/model/PostTest.kt
+++ b/src/test/kotlin/com/teamsparta/buysell/domain/post/model/PostTest.kt
@@ -71,7 +71,8 @@ class PostTest: BehaviorSpec({
                 title = "수정된 게시글 테스트",
                 content = "수정된 게시글 내용",
                 price = 9999999,
-                category = Category.PET)
+                category = Category.PET,
+                imageUrl = "")
             then("객체가 수정되어야 한다.") {
                 ipadPost.postUpdate(updateRequest)
 

--- a/src/test/kotlin/com/teamsparta/buysell/domain/post/service/PostServiceUnitTest.kt
+++ b/src/test/kotlin/com/teamsparta/buysell/domain/post/service/PostServiceUnitTest.kt
@@ -53,7 +53,8 @@ class PostServiceUnitTest: BehaviorSpec({
         title = "의자 팝니다",
         content = "네고 없습니다",
         price = 100000,
-        category = Category.INTERIOR
+        category = Category.INTERIOR,
+        imageUrl = ""
     )
 
     val member = Member(


### PR DESCRIPTION
## 의도
어떤 의도로 코드를 작성했는지 적어주세요
- 게시글 수정 시 이미지 수정을 위해 request에 imageUrl을 추가했습니다.

## 주요 변경점
어떤 부분이 변경되었는지 적어주세요
- updatePostRequest에 imageUrl을 추가했고, 서비스 코드에서 사용하는 update 관련 메서드에 imageUrl을 추가했습니다.

## ETC
리뷰어들에게 어떤 점을 검토해야하는지 알려주세요
- 오타가 있는지 확인부탁드립니다.